### PR TITLE
index: exclude .worktrees from markdown discovery

### DIFF
--- a/skills/kb-search/gitmark.py
+++ b/skills/kb-search/gitmark.py
@@ -35,7 +35,7 @@ VERSION = "0.1.0"
 EXCLUDE_DIRS = {
     ".git", "node_modules", ".next", "dist", "build", "__pycache__",
     ".pytest_cache", "_vendor", ".venv", "venv", "vendor",
-    ".gitmark",
+    ".gitmark", ".worktrees",
 }
 DB_REL = ".gitmark/index.db"
 HEAD_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*$")

--- a/skills/kb-search/gitmark.py
+++ b/skills/kb-search/gitmark.py
@@ -8,7 +8,7 @@ Source of truth = markdown. Всё производное (поисковый и
 (n-gram: substring, опечатки, кириллица). Чистый python stdlib. Оффлайн.
 
 Команды:
-    gitmark index  [--root .] [--force]      построить/обновить индекс
+    gitmark [--root .] index [--force]       построить/обновить индекс
     gitmark search "<q>" [-k 8] [--json]      искать (bm25 ∪ trigram)
     gitmark map   [-o docs/docs-map.html]     self-contained HTML: дерево+рендер+граф
     gitmark serve [-p 8799]                   локальный http для просмотра HTML


### PR DESCRIPTION
Repos that keep git worktrees inside the checkout (a common convention is a top-level `.worktrees/` directory — Claude Code's worktree isolation uses it too) get every doc discovered twice: once from the main tree, once from the worktree copy. Duplicate chunks show up as duplicate search hits and skew bm25 ranking.

This adds `.worktrees` to `EXCLUDE_DIRS`, same spirit as the existing `.gitmark` / `node_modules` entries. Deliberately name-based: nested git checkouts themselves stay indexable — that's the whole point of workspace-wide search.

Second commit is a docstring fix we tripped over in practice: `--root` is a global argparse flag, so it's `gitmark [--root .] index`, not `gitmark index [--root .]`.

Context: found while running gitmark over a ~650-file multi-repo workspace. gitmark.py is vendored (with attribution, MIT) as the retrieval layer in [claude-skills-3plus1](https://github.com/yurictl/claude-skills-3plus1) — the 3+1 docs framework converges on the same "markdown + README index + git" substrate bet as OntoShip, from the lifecycle side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
